### PR TITLE
Add food API with image upload using AWS S3

### DIFF
--- a/src/main/java/com/dev/BiteNowAPI/controller/FoodController.java
+++ b/src/main/java/com/dev/BiteNowAPI/controller/FoodController.java
@@ -1,0 +1,40 @@
+package com.dev.BiteNowAPI.controller;
+
+import com.dev.BiteNowAPI.io.FoodRequest;
+import com.dev.BiteNowAPI.io.FoodResponse;
+import com.dev.BiteNowAPI.service.FoodService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("api/foods")
+@AllArgsConstructor
+public class FoodController {
+
+    private final FoodService foodService;
+
+    @PostMapping
+    public FoodResponse addFood(@RequestPart("food") String foodString, @RequestPart("file") MultipartFile file) {
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        FoodRequest request = null;
+
+        try{
+            request = objectMapper.readValue(foodString, FoodRequest.class);
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid JSON format");
+        }
+
+        FoodResponse response = foodService.addFood(request, file);
+
+        return response;
+    }
+}

--- a/src/main/java/com/dev/BiteNowAPI/entity/FoodEntity.java
+++ b/src/main/java/com/dev/BiteNowAPI/entity/FoodEntity.java
@@ -1,0 +1,24 @@
+package com.dev.BiteNowAPI.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(collection = "foods")
+public class FoodEntity {
+
+    @Id
+    private String id;
+    private String name;
+    private String description;
+    private String imageUrl;
+    private double price;
+    private String category;
+}

--- a/src/main/java/com/dev/BiteNowAPI/io/FoodRequest.java
+++ b/src/main/java/com/dev/BiteNowAPI/io/FoodRequest.java
@@ -1,0 +1,17 @@
+package com.dev.BiteNowAPI.io;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FoodRequest {
+
+    private String name;
+    private String description;
+    private double price;
+    private String category;
+
+}

--- a/src/main/java/com/dev/BiteNowAPI/io/FoodResponse.java
+++ b/src/main/java/com/dev/BiteNowAPI/io/FoodResponse.java
@@ -1,0 +1,20 @@
+package com.dev.BiteNowAPI.io;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FoodResponse {
+
+    private String id;
+    private String name;
+    private String description;
+    private String imageUrl;
+    private double price;
+    private String category;
+}

--- a/src/main/java/com/dev/BiteNowAPI/repository/FoodRepository.java
+++ b/src/main/java/com/dev/BiteNowAPI/repository/FoodRepository.java
@@ -1,0 +1,9 @@
+package com.dev.BiteNowAPI.repository;
+
+import com.dev.BiteNowAPI.entity.FoodEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FoodRepository extends MongoRepository<FoodEntity, String> {
+}

--- a/src/main/java/com/dev/BiteNowAPI/service/FoodService.java
+++ b/src/main/java/com/dev/BiteNowAPI/service/FoodService.java
@@ -1,0 +1,14 @@
+package com.dev.BiteNowAPI.service;
+
+import com.dev.BiteNowAPI.io.FoodRequest;
+import com.dev.BiteNowAPI.io.FoodResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface FoodService {
+    String uploadFile(MultipartFile file);
+
+    FoodResponse addFood(FoodRequest request, MultipartFile file);
+
+}

--- a/src/main/java/com/dev/BiteNowAPI/service/FoodServiceImpl.java
+++ b/src/main/java/com/dev/BiteNowAPI/service/FoodServiceImpl.java
@@ -1,0 +1,97 @@
+package com.dev.BiteNowAPI.service;
+
+import com.dev.BiteNowAPI.entity.FoodEntity;
+import com.dev.BiteNowAPI.io.FoodRequest;
+import com.dev.BiteNowAPI.io.FoodResponse;
+import com.dev.BiteNowAPI.repository.FoodRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+@Service
+public class FoodServiceImpl implements FoodService {
+
+    private final S3Client s3Client;
+    private final FoodRepository foodRepository;
+    private final String bucketName;
+
+    public FoodServiceImpl(
+            S3Client s3Client,
+            FoodRepository foodRepository,
+            @Value("${aws.s3.bucketname}") String bucketName
+    ) {
+        this.s3Client = s3Client;
+        this.foodRepository = foodRepository;
+        this.bucketName = bucketName;
+    }
+
+    @Override
+    public String uploadFile(MultipartFile file) {
+        String filenameExtension = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf(".") + 1);
+        String key = UUID.randomUUID().toString() + "." + filenameExtension;
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .acl("public-read")
+                    .contentType(file.getContentType())
+                    .build();
+
+            PutObjectResponse response = s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));
+
+            if (response.sdkHttpResponse().isSuccessful()) {
+                return "https://" + bucketName + ".s3.amazonaws.com/" + key;
+            } else {
+                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "File upload failed");
+            }
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "An error occured while uploading the file");
+        }
+    }
+
+    @Override
+    public FoodResponse addFood(FoodRequest request, MultipartFile file) {
+        FoodEntity newFoodEntity = convertToEntity(request);
+        String imageUrl = uploadFile(file);
+        newFoodEntity.setImageUrl(imageUrl);
+
+        newFoodEntity = foodRepository.save(newFoodEntity);
+
+        return convertToResponse(newFoodEntity);
+    }
+
+
+    private FoodEntity convertToEntity(FoodRequest request) {
+        return FoodEntity.builder()
+                .name(request.getName())
+                .description(request.getDescription())
+                .category(request.getCategory())
+                .price(request.getPrice())
+                .build();
+    }
+
+    private FoodResponse convertToResponse(FoodEntity entity) {
+        return FoodResponse.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .description(entity.getDescription())
+                .category(entity.getCategory())
+                .price(entity.getPrice())
+                .imageUrl(entity.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,5 +8,5 @@ spring.data.mongodb.uri=${MONGODB_URI}
 aws.access.key=${AWS_ACCESS_KEY}
 aws.secret.key=${AWS_SECRET_KEY}
 aws.region=${AWS_REGION}
-
+aws.s3.bucketname=amzn-s3-bitenow
 


### PR DESCRIPTION
This PR introduces the Food management API with AWS S3 integration.

Changes included:
- Implemented FoodController for handling multipart food creation
- Added FoodRequest and FoodResponse DTOs
- Created FoodEntity and MongoDB repository
- Implemented FoodService and FoodServiceImpl
- Integrated AWS S3 for image uploads
- Stored uploaded image URLs in MongoDB

This enables creating food items with images uploaded to S3 and persisted in the database.
