### PR TITLE
feat: add read foods API endpoint

### DIFF
--- a/src/main/java/com/dev/BiteNowAPI/controller/FoodController.java
+++ b/src/main/java/com/dev/BiteNowAPI/controller/FoodController.java
@@ -7,12 +7,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("api/foods")
@@ -33,8 +32,12 @@ public class FoodController {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid JSON format");
         }
 
-        FoodResponse response = foodService.addFood(request, file);
-
-        return response;
+        return foodService.addFood(request, file);
     }
+
+    @GetMapping
+    public List<FoodResponse> readFoods() {
+        return foodService.readFoods();
+    }
+
 }

--- a/src/main/java/com/dev/BiteNowAPI/service/FoodService.java
+++ b/src/main/java/com/dev/BiteNowAPI/service/FoodService.java
@@ -11,4 +11,6 @@ public interface FoodService {
 
     FoodResponse addFood(FoodRequest request, MultipartFile file);
 
+    List<FoodResponse> readFoods() ;
+
 }

--- a/src/main/java/com/dev/BiteNowAPI/service/FoodServiceImpl.java
+++ b/src/main/java/com/dev/BiteNowAPI/service/FoodServiceImpl.java
@@ -74,6 +74,12 @@ public class FoodServiceImpl implements FoodService {
         return convertToResponse(newFoodEntity);
     }
 
+    @Override
+    public List<FoodResponse> readFoods() {
+        List<FoodEntity> databaseEntries = foodRepository.findAll();
+        return databaseEntries.stream().map(this::convertToResponse).collect(Collectors.toList());
+    }
+
 
     private FoodEntity convertToEntity(FoodRequest request) {
         return FoodEntity.builder()


### PR DESCRIPTION
### What was done
- Added GET endpoint to retrieve all food items
- Implemented service method to fetch food data from MongoDB
- Converted entities to response DTOs

### Endpoint
- GET /api/foods

### Notes
- Uses stream mapping for clean DTO conversion
- No breaking changes introduced
