### PR TITLE
feat: add get food by id endpoint

### DIFF
--- a/src/main/java/com/dev/BiteNowAPI/controller/FoodController.java
+++ b/src/main/java/com/dev/BiteNowAPI/controller/FoodController.java
@@ -40,4 +40,9 @@ public class FoodController {
         return foodService.readFoods();
     }
 
+    @GetMapping("/{id}")
+    public FoodResponse readFood(@PathVariable String id) {
+        return foodService.readFood(id);
+    }
+
 }

--- a/src/main/java/com/dev/BiteNowAPI/service/FoodService.java
+++ b/src/main/java/com/dev/BiteNowAPI/service/FoodService.java
@@ -13,4 +13,6 @@ public interface FoodService {
 
     List<FoodResponse> readFoods() ;
 
+    FoodResponse readFood(String id);
+
 }

--- a/src/main/java/com/dev/BiteNowAPI/service/FoodServiceImpl.java
+++ b/src/main/java/com/dev/BiteNowAPI/service/FoodServiceImpl.java
@@ -80,6 +80,12 @@ public class FoodServiceImpl implements FoodService {
         return databaseEntries.stream().map(this::convertToResponse).collect(Collectors.toList());
     }
 
+    @Override
+    public FoodResponse readFood(String id) {
+        FoodEntity existingFood = foodRepository.findById(id).orElseThrow(()-> new RuntimeException("Food not found for the id: "+ id));
+        return convertToResponse(existingFood);
+    }
+
 
     private FoodEntity convertToEntity(FoodRequest request) {
         return FoodEntity.builder()


### PR DESCRIPTION
### What was done
- Added GET endpoint to retrieve a single food item by ID
- Implemented service method to fetch food from MongoDB
- Throws exception when food is not found

### Endpoint
- GET /api/foods/{id}

### Notes
- Reuses existing entity-to-response mapping
- No impact on existing list or create APIs
