### PR TITLE
feat: add food deletion with S3 image cleanup

### DIFF
--- a/src/main/java/com/dev/BiteNowAPI/controller/FoodController.java
+++ b/src/main/java/com/dev/BiteNowAPI/controller/FoodController.java
@@ -45,4 +45,9 @@ public class FoodController {
         return foodService.readFood(id);
     }
 
+    @DeleteMapping("/{id}")
+    public void deleteFood(@PathVariable String id) {
+      foodService.deleteFood(id);
+    }
+
 }

--- a/src/main/java/com/dev/BiteNowAPI/service/FoodService.java
+++ b/src/main/java/com/dev/BiteNowAPI/service/FoodService.java
@@ -15,4 +15,7 @@ public interface FoodService {
 
     FoodResponse readFood(String id);
 
+    boolean deleteFile(String filename);
+
+    void deleteFood(String id);
 }

--- a/src/main/java/com/dev/BiteNowAPI/service/FoodServiceImpl.java
+++ b/src/main/java/com/dev/BiteNowAPI/service/FoodServiceImpl.java
@@ -4,7 +4,6 @@ import com.dev.BiteNowAPI.entity.FoodEntity;
 import com.dev.BiteNowAPI.io.FoodRequest;
 import com.dev.BiteNowAPI.io.FoodResponse;
 import com.dev.BiteNowAPI.repository.FoodRepository;
-import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -12,13 +11,13 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 @Service
@@ -84,6 +83,31 @@ public class FoodServiceImpl implements FoodService {
     public FoodResponse readFood(String id) {
         FoodEntity existingFood = foodRepository.findById(id).orElseThrow(()-> new RuntimeException("Food not found for the id: "+ id));
         return convertToResponse(existingFood);
+    }
+
+    @Override
+    public boolean deleteFile(String filename) {
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(filename)
+                .build();
+
+        s3Client.deleteObject(deleteObjectRequest);
+
+        return true;
+    }
+
+    @Override
+    public void deleteFood(String id) {
+        FoodResponse response = readFood(id);
+        String imageUrl = response.getImageUrl();
+        String filename = imageUrl.substring(imageUrl.lastIndexOf("/")+1);
+
+        boolean isFileDeleted = deleteFile(filename);
+
+        if (isFileDeleted) {
+            foodRepository.deleteById(response.getId());
+        }
     }
 
 


### PR DESCRIPTION
This PR adds support for deleting food items along with their associated
images stored in AWS S3.

Changes include:
- Added DELETE /api/foods/{id} endpoint
- Implemented food deletion logic in service layer
- Deletes corresponding S3 object before removing the database record
- Ensures data consistency between MongoDB and S3

This improves storage management and prevents orphaned files in S3.
