### PR TITLE
feat: add user registration API with MongoDB persistence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,10 @@
 			<artifactId>s3</artifactId>
 			<version>2.40.17</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/dev/BiteNowAPI/controller/UserController.java
+++ b/src/main/java/com/dev/BiteNowAPI/controller/UserController.java
@@ -1,0 +1,22 @@
+package com.dev.BiteNowAPI.controller;
+
+import com.dev.BiteNowAPI.io.UserRequest;
+import com.dev.BiteNowAPI.io.UserResponse;
+import com.dev.BiteNowAPI.service.UserService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/register")
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserResponse register(@RequestBody UserRequest request) {
+        return userService.registerUser(request);
+    }
+}

--- a/src/main/java/com/dev/BiteNowAPI/entity/UserEntity.java
+++ b/src/main/java/com/dev/BiteNowAPI/entity/UserEntity.java
@@ -1,0 +1,23 @@
+package com.dev.BiteNowAPI.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Document(collection = "users")
+public class UserEntity {
+
+    @Id
+    private String id;
+    private String name;
+    private String email;
+    private String password;
+
+}

--- a/src/main/java/com/dev/BiteNowAPI/io/AuthenticationRequest.java
+++ b/src/main/java/com/dev/BiteNowAPI/io/AuthenticationRequest.java
@@ -1,0 +1,14 @@
+package com.dev.BiteNowAPI.io;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthenticationRequest {
+
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/dev/BiteNowAPI/io/AuthenticationResponse.java
+++ b/src/main/java/com/dev/BiteNowAPI/io/AuthenticationResponse.java
@@ -1,0 +1,11 @@
+package com.dev.BiteNowAPI.io;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AuthenticationResponse {
+    private String email;
+    private String token;
+}

--- a/src/main/java/com/dev/BiteNowAPI/io/UserRequest.java
+++ b/src/main/java/com/dev/BiteNowAPI/io/UserRequest.java
@@ -1,0 +1,17 @@
+package com.dev.BiteNowAPI.io;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserRequest {
+
+    private String name;
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/dev/BiteNowAPI/io/UserResponse.java
+++ b/src/main/java/com/dev/BiteNowAPI/io/UserResponse.java
@@ -1,0 +1,17 @@
+package com.dev.BiteNowAPI.io;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserResponse {
+
+    private String id;
+    private String name;
+    private String email;
+}

--- a/src/main/java/com/dev/BiteNowAPI/repository/UserRepository.java
+++ b/src/main/java/com/dev/BiteNowAPI/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.dev.BiteNowAPI.repository;
+
+import com.dev.BiteNowAPI.entity.UserEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends MongoRepository<UserEntity, String> {
+    Optional<UserEntity> findByEmail(String email);
+}

--- a/src/main/java/com/dev/BiteNowAPI/service/UserService.java
+++ b/src/main/java/com/dev/BiteNowAPI/service/UserService.java
@@ -1,0 +1,8 @@
+package com.dev.BiteNowAPI.service;
+
+import com.dev.BiteNowAPI.io.UserRequest;
+import com.dev.BiteNowAPI.io.UserResponse;
+
+public interface UserService {
+    UserResponse registerUser(UserRequest request);
+}

--- a/src/main/java/com/dev/BiteNowAPI/service/UserServiceImpl.java
+++ b/src/main/java/com/dev/BiteNowAPI/service/UserServiceImpl.java
@@ -1,0 +1,39 @@
+package com.dev.BiteNowAPI.service;
+
+import com.dev.BiteNowAPI.entity.UserEntity;
+import com.dev.BiteNowAPI.io.UserRequest;
+import com.dev.BiteNowAPI.io.UserResponse;
+import com.dev.BiteNowAPI.repository.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserResponse registerUser(UserRequest request) {
+        UserEntity newUser = convertToEntity(request);
+        newUser = userRepository.save(newUser);
+        return convertToResponse(newUser);
+
+    }
+
+    private UserEntity convertToEntity(UserRequest request) {
+        return UserEntity.builder()
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .name(request.getName())
+                .build();
+    }
+
+    private UserResponse convertToResponse(UserEntity registeredUser) {
+        return UserResponse.builder()
+                .id(registeredUser.getId())
+                .email(registeredUser.getEmail())
+                .name(registeredUser.getName())
+                .build();
+    }
+}


### PR DESCRIPTION
This PR introduces the initial user management functionality.

Key changes:
- Added User entity mapped to MongoDB
- Implemented user registration service and repository
- Created POST /api/register endpoint
- Added request and response DTOs for user data
- Ensured proper separation of controller, service, and persistence layers

This lays the foundation for future authentication and authorization
features such as login and JWT-based security.
