### PR TITLE
feat(order): create order and integrate Stripe checkout with webhook …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,16 @@
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.stripe</groupId>
+			<artifactId>stripe-java</artifactId>
+			<version>24.10.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.10.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/dev/BiteNowAPI/config/SecurityConfig.java
+++ b/src/main/java/com/dev/BiteNowAPI/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
         http
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth.requestMatchers("/api/register", "/api/login", "/api/foods/**").permitAll().anyRequest().authenticated())
+                .authorizeHttpRequests(auth -> auth.requestMatchers("/api/register", "/api/login", "/api/foods/**", "/api/webhook/stripe").permitAll().anyRequest().authenticated())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/dev/BiteNowAPI/controller/OrderController.java
+++ b/src/main/java/com/dev/BiteNowAPI/controller/OrderController.java
@@ -1,0 +1,28 @@
+package com.dev.BiteNowAPI.controller;
+
+import com.dev.BiteNowAPI.io.OrderRequest;
+import com.dev.BiteNowAPI.io.OrderResponse;
+import com.dev.BiteNowAPI.service.OrderService;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+@AllArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping("/create")
+    public OrderResponse createOrderWithPayment(@RequestBody OrderRequest request) {
+        try {
+            return orderService.createOrderWithPayment(request);
+        } catch (Exception e) {
+            throw new RuntimeException("Order creation failed", e);
+        }
+    }
+
+}

--- a/src/main/java/com/dev/BiteNowAPI/controller/StripeWebhookController.java
+++ b/src/main/java/com/dev/BiteNowAPI/controller/StripeWebhookController.java
@@ -1,0 +1,25 @@
+package com.dev.BiteNowAPI.controller;
+
+
+import com.dev.BiteNowAPI.service.OrderService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/webhook")
+public class StripeWebhookController {
+
+    private final OrderService orderService;
+
+    @PostMapping("/stripe")
+    public ResponseEntity<String> handleStripeEvent(
+            @RequestBody String payload,
+            @RequestHeader("Stripe-Signature") String sigHeader) {
+
+        orderService.verifyPayment(payload, sigHeader);
+        return ResponseEntity.ok("Webhook received");
+    }
+
+}

--- a/src/main/java/com/dev/BiteNowAPI/entity/OrderEntity.java
+++ b/src/main/java/com/dev/BiteNowAPI/entity/OrderEntity.java
@@ -1,0 +1,28 @@
+package com.dev.BiteNowAPI.entity;
+
+import com.dev.BiteNowAPI.io.OrderItem;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Data
+@Builder
+@Document(collection = "orders")
+public class OrderEntity {
+
+    @Id
+    private String id;
+    private String userId;
+    private String userAddress;
+    private String phoneNumber;
+    private String email;
+    private List<OrderItem> orderedItems;
+    private double amount;
+    private String paymentStatus;
+    private String stripeOrderId;
+    private String orderStatus;
+
+}

--- a/src/main/java/com/dev/BiteNowAPI/io/OrderItem.java
+++ b/src/main/java/com/dev/BiteNowAPI/io/OrderItem.java
@@ -1,0 +1,18 @@
+package com.dev.BiteNowAPI.io;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class OrderItem {
+
+    private String foodID;
+    private int quantity;
+    private double price;
+    private String category;
+    private String imageUrl;
+    private String description;
+    private String name;
+
+}

--- a/src/main/java/com/dev/BiteNowAPI/io/OrderRequest.java
+++ b/src/main/java/com/dev/BiteNowAPI/io/OrderRequest.java
@@ -1,0 +1,22 @@
+package com.dev.BiteNowAPI.io;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderRequest {
+
+    private List<OrderItem> orderItems;
+    private String phoneNumber;
+    private String email;
+    private String userAddress;
+    private double amount;
+
+}

--- a/src/main/java/com/dev/BiteNowAPI/io/OrderResponse.java
+++ b/src/main/java/com/dev/BiteNowAPI/io/OrderResponse.java
@@ -1,0 +1,23 @@
+package com.dev.BiteNowAPI.io;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderResponse {
+
+    private String id;
+    private String userAddress;
+    private String phoneNumber;
+    private String email;
+    private double amount;
+    private String paymentStatus;
+    private String stripeOrderId;
+    private String checkoutUrl;
+    private String orderStatus;
+}

--- a/src/main/java/com/dev/BiteNowAPI/repository/OrderRepository.java
+++ b/src/main/java/com/dev/BiteNowAPI/repository/OrderRepository.java
@@ -1,0 +1,16 @@
+package com.dev.BiteNowAPI.repository;
+
+import com.dev.BiteNowAPI.entity.OrderEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface OrderRepository extends MongoRepository<OrderEntity, String> {
+
+    List<OrderEntity> findByUserId(String userId);
+
+    Optional<OrderEntity> findByStripeOrderId(String stripeOrderId);
+}

--- a/src/main/java/com/dev/BiteNowAPI/service/OrderService.java
+++ b/src/main/java/com/dev/BiteNowAPI/service/OrderService.java
@@ -1,0 +1,11 @@
+package com.dev.BiteNowAPI.service;
+
+import com.dev.BiteNowAPI.io.OrderRequest;
+import com.dev.BiteNowAPI.io.OrderResponse;
+
+public interface   OrderService {
+
+    OrderResponse createOrderWithPayment(OrderRequest request);
+
+    void verifyPayment(String payload, String sigHeader);
+}

--- a/src/main/java/com/dev/BiteNowAPI/service/OrderServiceImpl.java
+++ b/src/main/java/com/dev/BiteNowAPI/service/OrderServiceImpl.java
@@ -1,0 +1,168 @@
+package com.dev.BiteNowAPI.service;
+
+import com.dev.BiteNowAPI.entity.OrderEntity;
+import com.dev.BiteNowAPI.io.OrderRequest;
+import com.dev.BiteNowAPI.io.OrderResponse;
+import com.dev.BiteNowAPI.repository.CartRepository;
+import com.dev.BiteNowAPI.repository.OrderRepository;
+import com.stripe.Stripe;
+import com.stripe.exception.SignatureVerificationException;
+import com.stripe.model.Event;
+import com.stripe.model.checkout.Session;
+import com.stripe.net.Webhook;
+import com.stripe.param.checkout.SessionCreateParams;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+
+public class OrderServiceImpl implements OrderService {
+
+    private final OrderRepository orderRepository;
+    private final CartRepository cartRepository;
+    private final UserService userService;
+    @Value("${stripe.secret.key}")
+    private String stripeSecretKey;
+    @Value("${stripe.webhook.secret}")
+    private String webhookSecret;
+
+    public OrderServiceImpl(OrderRepository orderRepository, CartRepository cartRepository, UserService userService) {
+        this.orderRepository = orderRepository;
+        this.cartRepository = cartRepository;
+        this.userService = userService;
+    }
+
+    @Override
+    public OrderResponse createOrderWithPayment(OrderRequest request) {
+
+        try {
+            String loggedInUserId = userService.findByUserId();
+
+            OrderEntity order = convertToEntity(request);
+            order.setUserId(loggedInUserId);
+            order.setPaymentStatus("PENDING");
+            order.setOrderStatus("CREATED");
+
+            order = orderRepository.save(order);
+
+            Stripe.apiKey = stripeSecretKey;
+
+            SessionCreateParams params =
+                    SessionCreateParams.builder()
+                            .setMode(SessionCreateParams.Mode.PAYMENT)
+                            .setSuccessUrl("http://localhost:3000/payment-success?orderId=" + order.getId())
+                            .setCancelUrl("http://localhost:3000/payment-failed?orderId=" + order.getId())
+                            .addLineItem(
+                                    SessionCreateParams.LineItem.builder()
+                                            .setQuantity(1L)
+                                            .setPriceData(
+                                                    SessionCreateParams.LineItem.PriceData.builder()
+                                                            .setCurrency("lkr")
+                                                            .setUnitAmount((long) (order.getAmount() * 100))
+                                                            .setProductData(
+                                                                    SessionCreateParams.LineItem.PriceData.ProductData.builder()
+                                                                            .setName("Food Order - BiteNow")
+                                                                            .build()
+                                                            )
+                                                            .build()
+                                            )
+                                            .build()
+                            )
+                            .putMetadata("orderId", order.getId())
+                            .build();
+
+            Session session = Session.create(params);
+
+            order.setStripeOrderId(session.getId());
+            orderRepository.save(order);
+
+            OrderResponse response = convertToResponse(order);
+            response.setCheckoutUrl(session.getUrl());
+
+            return response;
+
+        } catch (Exception e) {
+            // You can later replace this with a custom exception
+            throw new RuntimeException("Failed to create order and initiate payment", e);
+        }
+    }
+
+    @Override
+    public void verifyPayment(String payload, String sigHeader) {
+
+        Event event;
+
+        try {
+            event = Webhook.constructEvent(payload, sigHeader, webhookSecret);
+        } catch (SignatureVerificationException e) {
+            throw new RuntimeException("Invalid Stripe webhook signature", e);
+        }
+
+        // Ignore unneeded events
+        if (event.getType().equals("checkout.session.completed")) {
+            handlePaymentSuccess(event);
+        }
+    }
+
+
+    private OrderEntity convertToEntity(OrderRequest request) {
+        return OrderEntity.builder()
+                .phoneNumber(request.getPhoneNumber())
+                .email(request.getEmail())
+                .userAddress(request.getUserAddress())
+                .amount(request.getAmount())
+                .orderedItems(request.getOrderItems())
+                .build();
+    }
+
+    private OrderResponse convertToResponse(OrderEntity newOrder) {
+        return OrderResponse.builder()
+                .id(newOrder.getId())
+                .userAddress(newOrder.getUserAddress())
+                .phoneNumber(newOrder.getPhoneNumber())
+                .email(newOrder.getEmail())
+                .amount(newOrder.getAmount())
+                .paymentStatus(newOrder.getPaymentStatus())
+                .stripeOrderId(newOrder.getStripeOrderId())
+                .orderStatus(newOrder.getOrderStatus())
+                .build();
+    }
+
+    @Transactional
+    private void handlePaymentSuccess(Event event) {
+
+        Session session = null;
+
+        if (event.getDataObjectDeserializer().getObject().isPresent()) {
+            session = (Session) event.getDataObjectDeserializer().getObject().get();
+        } else {
+            String rawJson = event.getData().getObject().toJson();
+            session = Session.GSON.fromJson(rawJson, Session.class);
+        }
+
+        if (session == null || session.getId() == null) {
+            throw new RuntimeException("Unable to deserialize checkout session");
+        }
+
+        Optional<OrderEntity> optionalOrder =
+                orderRepository.findByStripeOrderId(session.getId());
+
+        if (optionalOrder.isEmpty()) return;
+
+        OrderEntity order = optionalOrder.get();
+
+        if ("PAID".equals(order.getPaymentStatus())) {
+            return;
+        }
+
+        order.setPaymentStatus("PAID");
+        order.setOrderStatus("CONFIRMED");
+        orderRepository.save(order);
+
+        cartRepository.deleteByUserId(order.getUserId());
+    }
+}
+

--- a/src/main/java/com/dev/BiteNowAPI/util/JwtUtil.java
+++ b/src/main/java/com/dev/BiteNowAPI/util/JwtUtil.java
@@ -28,7 +28,7 @@ public class JwtUtil {
                 .setClaims(claims)
                 .setSubject(subject)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24 * 7))
                 .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
                 .compact();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,6 @@ aws.s3.bucketname=amzn-s3-bitenow
 
 jwt.secret.key=${JWT_SECRET_KEY}
 
+# Stripe configuration
+stripe.secret.key=${STRIPE_SECRET_KEY}
+stripe.webhook.secret=${STRIPE_WEBHOOK_SECRET}


### PR DESCRIPTION
## What was implemented
- Implemented order creation API with Stripe Checkout session
- Stored Stripe session ID against each order
- Integrated Stripe webhook handling for `checkout.session.completed`
- Updated order payment and order status after successful payment
- Cleared user cart after confirmed payment
- Added safe deserialization fallback for Stripe CLI mock events

## Why this change
- Enables end-to-end order placement with online payment
- Stripe success URLs are not reliable payment confirmation
- Webhooks provide a secure and reliable payment status update
- Ensures cart is cleared only after successful payment

## How it was tested
- Created order via `/api/orders/create`
- Completed payment using Stripe test card
- Used Stripe CLI to forward webhooks to localhost
- Verified order status update and cart cleanup in database

## Notes
- Webhook endpoint is unauthenticated as required by Stripe
- Designed to be safe against Stripe webhook retries
